### PR TITLE
Warn when a metric could not be published

### DIFF
--- a/RabbitMQAzureMetrics/RabbitMQMetricsProcessor.cs
+++ b/RabbitMQAzureMetrics/RabbitMQMetricsProcessor.cs
@@ -90,7 +90,7 @@
                                              logger,
                                              new QueueValueConverter(),
                                              httpClientFactory),
-                        new TelemetryClientPublisher(MetricsDefinitions.CreateQueueMetric(client)));
+                        new TelemetryClientPublisher(MetricsDefinitions.CreateQueueMetric(client), logger));
 
             var overviewProcessor = new DefaultMetricProcessor(
                         new RabbitMqMetricsConsumer(
@@ -99,7 +99,7 @@
                                              logger,
                                              new MessageOverviewValueConverter(),
                                              httpClientFactory),
-                        new TelemetryClientPublisher(MetricsDefinitions.CreateOverviewMetric(client)));
+                        new TelemetryClientPublisher(MetricsDefinitions.CreateOverviewMetric(client), logger));
 
             var exchangeProcessor = new DefaultMetricProcessor(
                         new RabbitMqMetricsConsumer(
@@ -108,7 +108,7 @@
                                              logger,
                                              new ExchangeValueConverter(),
                                              httpClientFactory),
-                        new TelemetryClientPublisher(MetricsDefinitions.CreateExchangewMetric(client)));
+                        new TelemetryClientPublisher(MetricsDefinitions.CreateExchangewMetric(client), logger));
 
             var processors = new List<IMetricProcessor>(3);
 

--- a/RabbitMQAzureMetrics/ValuePublishers/AppInsight/TelemetryClientPublisher.cs
+++ b/RabbitMQAzureMetrics/ValuePublishers/AppInsight/TelemetryClientPublisher.cs
@@ -1,4 +1,6 @@
-﻿namespace RabbitMQAzureMetrics.ValuePublishers.AppInsight
+﻿using Microsoft.Extensions.Logging;
+
+namespace RabbitMQAzureMetrics.ValuePublishers.AppInsight
 {
     using System;
     using System.Threading.Tasks;
@@ -8,10 +10,12 @@
     public class TelemetryClientPublisher : IMetricPublisher
     {
         private readonly Metric metric;
+        private readonly ILogger logger;
 
-        public TelemetryClientPublisher(Metric metric)
+        public TelemetryClientPublisher(Metric metric, ILogger logger)
         {
             this.metric = metric;
+            this.logger = logger;
         }
 
         public Task PublishAsync(MetricValueCollectionWrapper collector)
@@ -33,6 +37,7 @@
 
             var method = this.metric.GetType().GetMethod(nameof(this.metric.TrackValue), types);
             var parameters = new object[types.Length];
+            var result = true;
 
             foreach (var itm in collector.Values)
             {
@@ -42,7 +47,14 @@
                     parameters[i + 1] = itm.Dimensions[i];
                 }
 
-                method.Invoke(this.metric, parameters);
+                result &= (bool?)method.Invoke(this.metric, parameters) ?? true;
+            }
+
+            if (!result)
+            {
+                logger.LogError(
+                    "Could not publish all metrics, limits reached? Series count: {SeriesCount}, Collector count: {CollectorCount}",
+                    metric.SeriesCount, values.Count);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
By default a metric can only collect 1000 metrics. With 10 metrics per queue having >100 queues some metrics are mysteriously missing. This will log a warning when `TrackMetric` returns `false`.