### PR TITLE
Increase limits to support up to 1k queues

### DIFF
--- a/RabbitMQAzureMetrics/ValuePublishers/AppInsight/MetricsDefinitions.cs
+++ b/RabbitMQAzureMetrics/ValuePublishers/AppInsight/MetricsDefinitions.cs
@@ -1,4 +1,6 @@
-﻿namespace RabbitMQAzureMetrics.ValuePublishers.AppInsight
+﻿using RabbitMQAzureMetrics.ValuePublishers.Overview;
+
+namespace RabbitMQAzureMetrics.ValuePublishers.AppInsight
 {
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Metrics;
@@ -17,9 +19,11 @@
             return telemetryClient.GetMetric(new MetricIdentifier(MetricsNamespace, "Exchange", "Type", "Name"));
         }
 
-        public static Metric CreateQueueMetric(TelemetryClient telemetryClient)
+        public static Metric CreateQueueMetric(TelemetryClient telemetryClient, int queueLimit = 1_000)
         {
-            return telemetryClient.GetMetric(new MetricIdentifier(MetricsNamespace, "Queue", "Type", "Name"));
+            return telemetryClient.GetMetric(new MetricIdentifier(MetricsNamespace, "Queue", "Type", "Name"),
+                new MetricConfiguration(QueueValueConverter.PublishedMetrics.Count * queueLimit, queueLimit,
+                    new MetricSeriesConfigurationForMeasurement(restrictToUInt32Values: false)));
         }
     }
 }


### PR DESCRIPTION
With 10 metrics per queue the default limit of 1000 metrics means that we can only track 100 queues. This increases the limit to 1000 queues.

Note that subscriptions support 50k "active timeseries". Currently 23 metrics are tracker per queue, so having 1000 queues would result in 23k "active timeseries". If you have this many queues, a different logging strategy or filtering would be needed.