### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/Examples/StatsGenerator/RabbitMqConsumer.cs
+++ b/Examples/StatsGenerator/RabbitMqConsumer.cs
@@ -68,7 +68,7 @@ namespace StatsGenerator
             consumer.Received += (model, ea) =>
             {
                 var body = ea.Body;
-                var message = Encoding.UTF8.GetString(body);
+                var message = Encoding.UTF8.GetString(body.Span);
                 lock (rnd)
                 {
                     Thread.Sleep(rnd.Next(0, consumeMaxDelay));

--- a/Examples/StatsGenerator/StatsGenerator.csproj
+++ b/Examples/StatsGenerator/StatsGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/StatsGenerator/StatsGenerator.csproj
+++ b/Examples/StatsGenerator/StatsGenerator.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Polly" Version="8.3.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
   </ItemGroup>
 
 </Project>

--- a/RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj
+++ b/RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Polly" Version="8.3.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj
+++ b/RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj
+++ b/RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/RabbitMQAzureMetrics/RabbitMQMetricsProcessor.cs
+++ b/RabbitMQAzureMetrics/RabbitMQMetricsProcessor.cs
@@ -128,21 +128,24 @@
                 {
                     for (var i = 0; i < this.processors.Count; i++)
                     {
-                        await this.processors[i].ProcessAsync();
+                        await this.processors[i].ProcessAsync(cancellationToken);
                     }
 
                     this.FlushIfRequired();
 
                     await Task.Delay(Math.Max(MinPollingInterval, this.configuration.PollingInterval), cancellationToken);
                 }
-                catch (TaskCanceledException)
+                catch (TaskCanceledException exception)
                 {
-                    this.logger.LogDebug("stopping the metrics processor");
+                    this.logger.LogInformation(
+                        exception,
+                        "Stopping the metrics processor: {ErrorMessage}",
+                        exception.Message);
                     break;
                 }
-                catch (Exception ex)
+                catch (Exception exception)
                 {
-                    this.logger.LogError("Unexpected error: {error}", ex.Message);
+                    this.logger.LogError(exception, "Unexpected error: {ErrorMessage}", exception.Message);
 
                     Environment.ExitCode = -1;
                     this.appLifetime.StopApplication();

--- a/RabbitMQAzureMetrics/RabbitMqBackgroundService.cs
+++ b/RabbitMQAzureMetrics/RabbitMqBackgroundService.cs
@@ -9,7 +9,7 @@
     using RabbitMQAzureMetrics.Configuration;
     using RabbitMQAzureMetrics.Consumer;
 
-    internal class RabbitMqBackgroundService : IHostedService
+    internal class RabbitMqBackgroundService : BackgroundService
     {
         private readonly ILogger<RabbitMqBackgroundService> logger;
         private readonly RabbitMQMetricsProcessor processor;
@@ -26,16 +26,11 @@
             this.processor = new RabbitMQMetricsProcessor(telemetryClient, configuration, logger, clientFactory, metricsConsumerLogger, appLifetime);
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             this.logger.LogInformation("Starting RabbitMQ Metrics Service");
-            await this.processor.StartAsync(cancellationToken);
-        }
-
-        public async Task StopAsync(CancellationToken cancellationToken)
-        {
-            this.logger.LogInformation("Stopping RabbitMQ Metrics Service");
-            await this.processor.StopAsync(cancellationToken);
+            await this.processor.ExecuteAsync(stoppingToken);
+            this.logger.LogInformation("Stopped RabbitMQ Metrics Service");
         }
     }
 }

--- a/RabbitMQAzureMetricsRunner/Dockerfile
+++ b/RabbitMQAzureMetricsRunner/Dockerfile
@@ -1,9 +1,9 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/core/runtime:3.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj", "RabbitMQAzureMetricsRunner/"]
 COPY ["RabbitMQAzureMetrics/RabbitMQAzureMetrics.csproj", "RabbitMQAzureMetrics/"]

--- a/RabbitMQAzureMetricsRunner/GlobalSuppressions.cs
+++ b/RabbitMQAzureMetricsRunner/GlobalSuppressions.cs
@@ -1,7 +1,0 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
-
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Skipping documentation for sample code")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File should have header", Justification = "Skipping headers for sample code")]

--- a/RabbitMQAzureMetricsRunner/Program.cs
+++ b/RabbitMQAzureMetricsRunner/Program.cs
@@ -1,49 +1,16 @@
-﻿namespace RabbitMQAzureMetrics
-{
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Logging;
-    using RabbitMQAzureMetrics.Configuration;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using RabbitMQAzureMetrics;
+using RabbitMQAzureMetrics.Configuration;
 
-    public class Program
+using var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
     {
-        public static async Task Main(string[] args)
-        {
-            var hostBuilder = Setup(args);
-            using (var host = hostBuilder.Build())
-            {
-                await host.StartAsync();
-                await host.WaitForShutdownAsync();
-            }
-        }
+        var config = new RabbitMetricsConfiguration();
+        hostContext.Configuration.Bind(config);
+        services.AddRabbitMqMetrics(config);
+    })
+    .Build();
 
-        private static IHostBuilder Setup(string[] args)
-        {
-            var hostBuilder = new HostBuilder()
-                .ConfigureLogging((ctx, logging) =>
-                {
-                    logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
-                    logging.AddConsole();
-                })
-                .ConfigureAppConfiguration((ctx, config) =>
-                {
-                    config.AddJsonFile("appsettings.json", false);
-                    config.AddJsonFile("appsettings.local.json", true);
-                    config.AddCommandLine(args);
-                    config.AddEnvironmentVariables();
-                })
-                .ConfigureServices((hostContext, services) =>
-                {
-                    services.AddLogging();
-                    var config = new RabbitMetricsConfiguration();
-                    hostContext.Configuration.Bind(config);
-                    services.AddRabbitMqMetrics(config);
-                })
-                .UseConsoleLifetime();
-
-            return hostBuilder;
-        }
-    }
-}
+await host.StartAsync();
+await host.WaitForShutdownAsync();

--- a/RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj
+++ b/RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj
+++ b/RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj
+++ b/RabbitMQAzureMetricsRunner/RabbitMQAzureMetricsRunner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>

--- a/Tests/DockerIntegrationTestHelper/DockerIntegrationTestHelper.csproj
+++ b/Tests/DockerIntegrationTestHelper/DockerIntegrationTestHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/DockerIntegrationTestHelper/DockerIntegrationTestHelper.csproj
+++ b/Tests/DockerIntegrationTestHelper/DockerIntegrationTestHelper.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
   </ItemGroup>
   
 </Project>

--- a/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RabbitHelpers/RabbitMqConsumer.cs
+++ b/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RabbitHelpers/RabbitMqConsumer.cs
@@ -51,7 +51,7 @@ namespace RabbitMQAzureMetrics.Test.IntegrationTests
             consumer.Received += (model, ea) =>
             {
                 var body = ea.Body;
-                var message = Encoding.UTF8.GetString(body);
+                var message = Encoding.UTF8.GetString(body.Span);
                 Console.WriteLine(" [x] {0}", message);
                 if (consumeDelay > 0)
                 {

--- a/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RabbitMQAzureMetrics.Test.IntegrationTests.csproj
+++ b/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RabbitMQAzureMetrics.Test.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RabbitMQAzureMetrics.Test.IntegrationTests.csproj
+++ b/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RabbitMQAzureMetrics.Test.IntegrationTests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="nunit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RetryTests.cs
+++ b/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/RetryTests.cs
@@ -53,13 +53,13 @@ namespace RabbitMQAzureMetrics.Test.IntegrationTests
                         pollingInterval: 2000);
 
             // verify that there was nothing published
-            Assert.False(mre.WaitOne(1));
+            Assert.That(mre.WaitOne(1) == false);
 
             // start the container
             await RabbitMqTestFixture.RabbitTestContainer.StartAsync();
 
             // now the processor should recover
-            Assert.True(mre.WaitOne(60_000));
+            Assert.That(mre.WaitOne(60_000));
         }
 
         [Test]

--- a/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/TelemetryClientPublisherTests.cs
+++ b/Tests/RabbitMQAzureMetrics.Test.IntegrationTests/TelemetryClientPublisherTests.cs
@@ -14,6 +14,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace RabbitMQAzureMetrics.Test.IntegrationTests
 {
@@ -26,7 +28,7 @@ namespace RabbitMQAzureMetrics.Test.IntegrationTests
             var metricIdentifier = CreateMetricIdentifier(dimensions);
             var tc = new TelemetryClient(TelemetryConfiguration.CreateDefault());
             var metric = tc.GetMetric(metricIdentifier);
-            var publisher = new TelemetryClientPublisher(metric);
+            var publisher = new TelemetryClientPublisher(metric, Mock.Of<ILogger>());
             var collectionWrapper = new MetricValueCollectionWrapper();
             collectionWrapper.Add(0, dimensions);
 

--- a/Tests/RabbitMQAzureMetrics.Test.UnitTests/ParserTests.cs
+++ b/Tests/RabbitMQAzureMetrics.Test.UnitTests/ParserTests.cs
@@ -29,7 +29,7 @@ namespace RabbitMQAzureMetrics.Test.UnitTests
                 if (Array.IndexOf(valuesToSkip, label) != -1)
                     continue;
 
-                Assert.IsTrue(NearlyEqual(DefaultValue, val.Value), $"Invalid value for '{val.Dimensions[0]}'");
+                Assert.That(NearlyEqual(DefaultValue, val.Value), $"Invalid value for '{val.Dimensions[0]}'");
             }
         }
 

--- a/Tests/RabbitMQAzureMetrics.Test.UnitTests/RabbitMQAzureMetrics.Test.UnitTests.csproj
+++ b/Tests/RabbitMQAzureMetrics.Test.UnitTests/RabbitMQAzureMetrics.Test.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/RabbitMQAzureMetrics.Test.UnitTests/RabbitMQAzureMetrics.Test.UnitTests.csproj
+++ b/Tests/RabbitMQAzureMetrics.Test.UnitTests/RabbitMQAzureMetrics.Test.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="nunit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/debugerr.Test.Common/debugerr.Test.Common.csproj
+++ b/Tests/debugerr.Test.Common/debugerr.Test.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 

--- a/Tests/debugerr.Test.Common/debugerr.Test.Common.csproj
+++ b/Tests/debugerr.Test.Common/debugerr.Test.Common.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I've found that the runner stopped processing metrics after some time, but couldn't figure out. After adding additional logging I found that a `TaskCanceledException` was thrown and killed `RabbitMQMetricsProcessor`, however the host program kept running. This is because the host program in .NET Core 3 doesn't care about this. In .NET 6 a new flavour `BackgroundService` was introduced that handled such situations, and in .NET 8 it applies to _all_ `IHostedService`s. Now when `RabbitMQMetricsProcessor` stops, the host program will also stop. The container runner will then have the option to restart the container.

.NET Core 3 has been out of support for about 4 years now. .NET 8 is an LTS release with support for almost 3 years from now, thus a good candidate as an upgrade target. I've also rewritten `Main` with top-level statements and upgraded the analyzer to understand these statements.